### PR TITLE
Update azuredeploy.json

### DIFF
--- a/Resource_Deployment/azuredeploy.json
+++ b/Resource_Deployment/azuredeploy.json
@@ -5,7 +5,7 @@
     "parameters": {
         "UniquePrefixName": {
             "type": "string",
-            "defaultValue": "hub",
+            "defaultValue": "SG",
             "minLength": 3,
             "maxLength": 10,
             "metadata": {
@@ -185,11 +185,11 @@
                 "autoScale": {
                     "enabled": true,
                     "minNodeCount": 3,
-                    "maxNodeCount": 15
+                    "maxNodeCount": 6
                 },
                 "autoPause": {
                     "enabled": true,
-                    "delayInMinutes": 15
+                    "delayInMinutes": 8
                 },
                 "isComputeIsolationEnabled": false,
                 "sessionLevelPackagesEnabled": false,
@@ -363,7 +363,7 @@
             "properties": {
               "options": {
                 "autoscaleSettings": {
-                  "maxThroughput": 100000
+                  "maxThroughput": 4000
                 }
               },
               "resource": {
@@ -1045,7 +1045,7 @@
                         "osDiskSizeGB": 0,
                         "count": 3,
                         "enableAutoScaling": true,
-                        "minCount": 1,
+                        "minCount": 3,
                         "maxCount": 5,
                         "vmSize": "Standard_DS2_v2",
                         "osType": "Linux",


### PR DESCRIPTION
Updated the changes in :
1. maxNodeCount to 6 from 15 for Medium sized Apache Spark Pool
2. CosmosDB maxThroughput to 4000 from 100000 (can't go below 4000 for some reason)
3. AKS minCount of node to 3 from 1 in auto-scaling. Since ML model requires at least 3 nodes to be running before the model is deployed.

Details (Preview Changes)


"parameters": {
        "UniquePrefixName": {
            "type": "string",
            "defaultValue": "hub",
            "defaultValue": "SG",
            "minLength": 3,
            "maxLength": 10,
            "metadata": {
@@ -185,11 +185,11 @@
                "autoScale": {
                    "enabled": true,
                    "minNodeCount": 3,
                    "maxNodeCount": 15
                    "maxNodeCount": 6
                },
                "autoPause": {
                    "enabled": true,
                    "delayInMinutes": 15
                    "delayInMinutes": 8
                },
                "isComputeIsolationEnabled": false,
                "sessionLevelPackagesEnabled": false,
@@ -363,7 +363,7 @@
            "properties": {
              "options": {
                "autoscaleSettings": {
                  "maxThroughput": 100000
                  "maxThroughput": 4000
                }
              },
              "resource": {
@@ -1045,7 +1045,7 @@
                        "osDiskSizeGB": 0,
                        "count": 3,
                        "enableAutoScaling": true,
                        "minCount": 1,
                        "minCount": 3,
                        "maxCount": 5,
                        "vmSize": "Standard_DS2_v2",
                        "osType": "Linux",